### PR TITLE
Add smooth animations to home, SMIF, about and learn pages

### DIFF
--- a/client/src/components/Motion.tsx
+++ b/client/src/components/Motion.tsx
@@ -1,0 +1,38 @@
+import { motion } from "framer-motion";
+import type { PropsWithChildren } from "react";
+
+const containerVariants = {
+  hidden: {},
+  show: {
+    transition: {
+      staggerChildren: 0.08,
+    },
+  },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 12 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.45, ease: "easeOut" } },
+};
+
+export function MotionContainer({ children, className }: PropsWithChildren<{ className?: string }>) {
+  return (
+    <motion.div
+      className={className}
+      initial="hidden"
+      animate="show"
+      variants={containerVariants}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function MotionItem(props: any) {
+  const { children, className, ...rest } = props;
+  return (
+    <motion.div className={className} variants={itemVariants} {...rest}>
+      {children}
+    </motion.div>
+  );
+}

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,6 +1,5 @@
 import { Link, useLocation } from "wouter";
 import { motion } from "framer-motion";
-import { TrendingUp } from "lucide-react";
 
 export default function Navbar() {
   const [location] = useLocation();
@@ -17,14 +16,11 @@ export default function Navbar() {
     <header className="glass sticky top-0 z-50 shadow-sm" data-testid="navbar">
       <nav className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
-          <Link href="/" data-testid="link-home">
-            <div className="flex items-center space-x-2 cursor-pointer">
-              <div className="w-10 h-10 gradient-primary rounded-lg flex items-center justify-center">
-                <TrendingUp className="text-white" size={20} />
-              </div>
-              <span className="text-xl font-bold text-foreground">FINBRIDGE</span>
+          <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/" data-testid="link-home">
+            <div className="flex items-center cursor-pointer">
+              <span className="ml-2 text-foreground" style={{ font: '700 20px/28px "Times New Roman", serif' }}>FINBRIDGE</span>
             </div>
-          </Link>
+          </a>
 
           <div className="hidden md:flex space-x-6">
             {navLinks.map((link) => (

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,17 +1,4 @@
-import { Link, useLocation } from "wouter";
-import { motion } from "framer-motion";
-
 export default function Navbar() {
-  const [location] = useLocation();
-
-  const navLinks = [
-    { href: "/", label: "Home" },
-    { href: "/screener", label: "Screener" },
-    { href: "/smif", label: "MAYS SMIF" },
-    { href: "/about", label: "About Us" },
-    { href: "/learn", label: "Learn" },
-  ];
-
   return (
     <header className="glass sticky top-0 z-50 shadow-sm" data-testid="navbar">
       <nav className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -22,35 +9,42 @@ export default function Navbar() {
             </div>
           </a>
 
-          <div className="hidden md:flex space-x-6">
-            {navLinks.map((link) => (
-              <Link key={link.href} href={link.href} data-testid={`link-${link.label.toLowerCase().replace(/\s+/g, '-')}`}>
-                <motion.a
-                  className={`text-sm font-medium transition-colors relative ${
-                    location === link.href
-                      ? "text-foreground"
-                      : "text-muted-foreground hover:text-foreground"
-                  }`}
-                  whileHover={{ y: -2 }}
-                >
-                  {link.label}
-                  {location === link.href && (
-                    <motion.div
-                      className="absolute -bottom-1 left-0 right-0 h-0.5 bg-primary"
-                      layoutId="navbar-indicator"
-                    />
-                  )}
-                </motion.a>
-              </Link>
-            ))}
+          <div className="flex font-medium">
+            <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/" className="block">
+              <div style={{ font: '500 14px/20px Times New Roman, serif', position: 'relative', transitionDuration: '0.15s', transitionProperty: 'color, background-color, border-color, text-decoration-color, fill, stroke', transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)' }}>
+                Home
+              </div>
+            </a>
+
+            <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/screener" className="block" style={{ marginLeft: '24px' }}>
+              <div style={{ font: '500 14px/20px Times New Roman, serif', position: 'relative', transitionDuration: '0.15s', transitionProperty: 'color, background-color, border-color, text-decoration-color, fill, stroke', transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)' }}>
+                Screener
+              </div>
+            </a>
+
+            <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/smif" className="block" style={{ marginLeft: '24px' }}>
+              <div style={{ font: '500 14px/20px Times New Roman, serif', position: 'relative', transitionDuration: '0.15s', transitionProperty: 'color, background-color, border-color, text-decoration-color, fill, stroke', transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)' }}>
+                MAYS SMIF
+              </div>
+            </a>
+
+            <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/about" className="block" style={{ marginLeft: '24px' }}>
+              <div style={{ position: 'relative', display: 'inline', transitionDuration: '0.15s', transitionProperty: 'color, background-color, border-color, text-decoration-color, fill, stroke', transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)', font: '500 14px/20px Times New Roman, serif' }}>
+                <div style={{ fontFamily: 'Times New Roman, serif' }}>About Us</div>
+                <div style={{ bottom: '-4px', fontWeight: 500, height: '2px', left: 0, position: 'absolute', right: 0 }} />
+              </div>
+            </a>
+
+            <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/learn" className="block" style={{ marginLeft: '24px' }}>
+              <div style={{ font: '500 14px/20px Times New Roman, serif', position: 'relative', transitionDuration: '0.15s', transitionProperty: 'color, background-color, border-color, text-decoration-color, fill, stroke', transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)' }}>
+                Learn
+              </div>
+            </a>
           </div>
 
-          <button
-            className="px-4 py-2 gradient-primary text-white rounded-lg text-sm font-medium hover:opacity-90 transition-opacity"
-            data-testid="button-get-started"
-          >
+          <div style={{ backgroundImage: 'linear-gradient(135deg, rgb(54, 143, 231) 0%, rgb(25, 117, 210) 100%)', borderRadius: '12px', color: 'rgb(255, 255, 255)', display: 'block', fontSize: '14px', fontWeight: 500, lineHeight: '20px', textDecoration: 'rgb(255, 255, 255)', transitionDuration: '0.15s', transitionProperty: 'opacity', transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)', backgroundColor: 'rgba(0, 0, 0, 0)', borderColor: 'rgba(0, 0, 0, 0)', padding: '8px 16px' }}>
             Get Started
-          </button>
+          </div>
         </div>
       </nav>
     </header>

--- a/client/src/pages/About.tsx
+++ b/client/src/pages/About.tsx
@@ -38,7 +38,7 @@ export default function About() {
     <section className="bg-muted min-h-screen py-20" data-testid="page-about">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
-          <h2 className="text-4xl font-bold text-foreground mb-4">About FINBRIDGE</h2>
+          <h2 className="text-4xl font-bold text-foreground mb-4">About <span style={{ fontFamily: 'Times New Roman, serif' }}>FINBRIDGE</span></h2>
           <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
             Bridging the gap between knowledge and capital markets
           </p>
@@ -46,10 +46,21 @@ export default function About() {
 
         {/* Philosophy */}
         <div className="bg-card rounded-xl p-8 border border-border mb-12">
-          <h3 className="text-2xl font-semibold text-foreground mb-4">Our Philosophy</h3>
-          <p className="text-lg text-muted-foreground leading-relaxed">
-            We believe investing should be transparent, accessible, and rooted in sound principles. Our philosophy centers on empowering individuals through knowledge and data-driven tools, enabling smarter and more confident decisions. By combining modern screening methods with long-term strategies, we help investors navigate markets with clarity and purpose.
-          </p>
+          <div className="flex items-start">
+            <div className="w-16 h-16 rounded-xl flex items-center justify-center flex-shrink-0" style={{ backgroundImage: 'linear-gradient(135deg, rgb(54, 143, 231) 0%, rgb(25, 117, 210) 100%)' }}>
+              <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                <path d="M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19 2c1 2 2 4.18 2 8 0 5.5-4.78 10-10 10Z" />
+                <path d="M2 21c0-3 1.85-5.36 5.08-6C9.5 14.52 12 13 13 12" />
+              </svg>
+            </div>
+
+            <div style={{ marginLeft: 16 }}>
+              <div className="text-2xl font-semibold text-foreground mb-4">Our Philosophy</div>
+              <div className="text-lg text-muted-foreground" style={{ lineHeight: '1.8' }}>
+                We believe investing should be transparent, accessible, and rooted in sound principles. Our philosophy centers on empowering individuals through knowledge and data-driven tools, enabling smarter and more confident decisions. By combining modern screening methods with long-term strategies, we help investors navigate markets with clarity and purpose.
+              </div>
+            </div>
+          </div>
         </div>
 
         {/* ESG Commitment */}

--- a/client/src/pages/About.tsx
+++ b/client/src/pages/About.tsx
@@ -1,6 +1,4 @@
 import { Leaf, Brain } from "lucide-react";
-
-import { Leaf, Brain } from "lucide-react";
 import { MotionContainer, MotionItem } from "@/components/Motion";
 
 const teamMembers = [

--- a/client/src/pages/About.tsx
+++ b/client/src/pages/About.tsx
@@ -1,5 +1,8 @@
 import { Leaf, Brain } from "lucide-react";
 
+import { Leaf, Brain } from "lucide-react";
+import { MotionContainer, MotionItem } from "@/components/Motion";
+
 const teamMembers = [
   {
     title: 'Chairman & CEO',
@@ -35,7 +38,7 @@ const teamMembers = [
 
 export default function About() {
   return (
-    <section className="bg-muted min-h-screen py-20" data-testid="page-about">
+    <MotionContainer className="bg-muted min-h-screen py-20" data-testid="page-about">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-4xl font-bold text-foreground mb-4">About <span style={{ fontFamily: 'Times New Roman, serif' }}>FINBRIDGE</span></h2>
@@ -45,7 +48,7 @@ export default function About() {
         </div>
 
         {/* Philosophy */}
-        <div className="bg-card rounded-xl p-8 border border-border mb-12 hover-lift transition-transform duration-200">
+        <MotionItem className="bg-card rounded-xl p-8 border border-border mb-12 hover-lift transition-transform duration-200">
           <div className="flex items-start">
             <div className="w-16 h-16 rounded-xl flex items-center justify-center flex-shrink-0" style={{ backgroundImage: 'linear-gradient(135deg, rgb(54, 143, 231) 0%, rgb(25, 117, 210) 100%)' }}>
               <Brain className="text-white" size={28} />
@@ -58,10 +61,10 @@ export default function About() {
               </div>
             </div>
           </div>
-        </div>
+        </MotionItem>
 
         {/* ESG Commitment */}
-        <div className="bg-card rounded-xl p-8 border border-border mb-12 hover-lift transition-transform duration-200">
+        <MotionItem className="bg-card rounded-xl p-8 border border-border mb-12 hover-lift transition-transform duration-200">
           <div className="flex items-start space-x-4">
             <div className="w-16 h-16 gradient-primary rounded-xl flex items-center justify-center flex-shrink-0">
               <Leaf className="text-white" size={28} />
@@ -73,14 +76,14 @@ export default function About() {
               </p>
             </div>
           </div>
-        </div>
+        </MotionItem>
 
         {/* Team */}
         <div className="mb-12">
           <h3 className="text-2xl font-semibold text-foreground mb-8 text-center">Our Team</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
             {teamMembers.map((member, index) => (
-              <div key={index} className="bg-card rounded-xl p-6 border border-border hover-lift" data-testid={`card-team-${index}`}>
+              <MotionItem key={index} className="bg-card rounded-xl p-6 border border-border hover-lift" data-testid={`card-team-${index}`}>
                 <img
                   src={member.image}
                   alt={member.title}
@@ -88,11 +91,11 @@ export default function About() {
                 />
                 <h4 className="text-lg font-bold text-foreground text-center mb-2">{member.title}</h4>
                 <p className="text-sm text-muted-foreground text-center">{member.description}</p>
-              </div>
+              </MotionItem>
             ))}
           </div>
         </div>
       </div>
-    </section>
+    </MotionContainer>
   );
 }

--- a/client/src/pages/About.tsx
+++ b/client/src/pages/About.tsx
@@ -1,5 +1,7 @@
 import { Leaf } from "lucide-react";
 
+import { Leaf, Brain } from "lucide-react";
+
 const teamMembers = [
   {
     title: 'Chairman & CEO',
@@ -45,13 +47,10 @@ export default function About() {
         </div>
 
         {/* Philosophy */}
-        <div className="bg-card rounded-xl p-8 border border-border mb-12">
+        <div className="bg-card rounded-xl p-8 border border-border mb-12 hover-lift transition-transform duration-200">
           <div className="flex items-start">
             <div className="w-16 h-16 rounded-xl flex items-center justify-center flex-shrink-0" style={{ backgroundImage: 'linear-gradient(135deg, rgb(54, 143, 231) 0%, rgb(25, 117, 210) 100%)' }}>
-              <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                <path d="M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19 2c1 2 2 4.18 2 8 0 5.5-4.78 10-10 10Z" />
-                <path d="M2 21c0-3 1.85-5.36 5.08-6C9.5 14.52 12 13 13 12" />
-              </svg>
+              <Brain className="text-white" size={28} />
             </div>
 
             <div style={{ marginLeft: 16 }}>
@@ -64,7 +63,7 @@ export default function About() {
         </div>
 
         {/* ESG Commitment */}
-        <div className="bg-card rounded-xl p-8 border border-border mb-12">
+        <div className="bg-card rounded-xl p-8 border border-border mb-12 hover-lift transition-transform duration-200">
           <div className="flex items-start space-x-4">
             <div className="w-16 h-16 gradient-primary rounded-xl flex items-center justify-center flex-shrink-0">
               <Leaf className="text-white" size={28} />

--- a/client/src/pages/About.tsx
+++ b/client/src/pages/About.tsx
@@ -1,5 +1,3 @@
-import { Leaf } from "lucide-react";
-
 import { Leaf, Brain } from "lucide-react";
 
 const teamMembers = [

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,7 +1,6 @@
 import { motion } from "framer-motion";
 import { ArrowRight, Filter, Users, GraduationCap } from "lucide-react";
 import { Link } from "wouter";
-import MarketWidgets from "@/components/MarketWidgets";
 
 export default function Home() {
   return (
@@ -23,19 +22,24 @@ export default function Home() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
           >
-            <h1 className="text-5xl md:text-6xl font-bold text-foreground mb-6 leading-tight" style={{ fontFamily: 'Times New Roman, serif' }}>
-              Bringing Wall Street to <span className="text-primary">Every Street</span>
+            <h1 className="text-5xl md:text-6xl font-bold text-foreground mb-6 leading-tight" style={{ font: '700 60px/60px "Times New Roman", serif' }}>
+              <div style={{ fontFamily: 'Times New Roman, serif' }}>
+                Bringing Wall Street to{" "}
+              </div>
+              <div className="inline font-bold" style={{ color: 'rgba(25, 95, 255, 1)' }}>
+                Every Street
+              </div>
             </h1>
-            <p className="text-xl text-muted-foreground mb-8 max-w-3xl mx-auto">
+            <p className="text-xl text-muted-foreground mb-8 max-w-3xl mx-auto" style={{ font: 'italic 400 20px/28px "Times New Roman", serif' }}>
               Our mission is to bridge the gap between knowledge and capital markets by offering cutting-edge screening tools and a first-of-its-kind Student Managed Investment Fund, fostering financial literacy and confident investing.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-              <Link href="/screener">
+              <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/screener">
                 <button className="px-8 py-4 gradient-primary text-white rounded-lg font-semibold hover:opacity-90 transition-all hover-lift text-lg" data-testid="button-start-screening" style={{ fontFamily: 'Times New Roman, serif' }}>
                   Start Screening Stocks
                   <ArrowRight className="inline ml-2" size={20} />
                 </button>
-              </Link>
+              </a>
               <Link href="/about">
                 <button className="px-8 py-4 glass-dark text-foreground rounded-lg font-semibold hover:opacity-90 transition-all hover-lift text-lg" data-testid="button-learn-more" style={{ fontFamily: 'Times New Roman, serif' }}>
                   Learn More
@@ -46,8 +50,6 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Market Widgets */}
-      <MarketWidgets />
 
       {/* Features Section */}
       <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20" data-testid="section-features">

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { motion } from "framer-motion";
 import { ArrowRight, Filter, Users, GraduationCap } from "lucide-react";
 import { Link } from "wouter";
+import { MotionContainer, MotionItem } from "@/components/Motion";
 
 export default function Home() {
   return (
@@ -16,37 +17,40 @@ export default function Home() {
         </div>
 
         <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
-          <motion.div
-            className="text-center max-w-4xl mx-auto"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-          >
-            <h1 className="text-5xl md:text-6xl font-bold text-foreground mb-6 leading-tight" style={{ font: '700 60px/60px "Times New Roman", serif' }}>
-              <div style={{ fontFamily: 'Times New Roman, serif' }}>
-                Bringing Wall Street to{" "}
+          <MotionContainer className="text-center max-w-4xl mx-auto">
+            <MotionItem>
+              <h1 className="text-5xl md:text-6xl font-bold text-foreground mb-6 leading-tight" style={{ font: '700 60px/60px "Times New Roman", serif' }}>
+                <div style={{ fontFamily: 'Times New Roman, serif' }}>
+                  Bringing Wall Street to{" "}
+                </div>
+                <div className="inline font-bold" style={{ color: 'rgba(25, 95, 255, 1)' }}>
+                  Every Street
+                </div>
+              </h1>
+            </MotionItem>
+
+            <MotionItem>
+              <p className="text-xl text-muted-foreground mb-8 max-w-3xl mx-auto" style={{ font: 'italic 400 20px/28px "Times New Roman", serif' }}>
+                Our mission is to bridge the gap between knowledge and capital markets by offering cutting-edge screening tools and a first-of-its-kind Student Managed Investment Fund, fostering financial literacy and confident investing.
+              </p>
+            </MotionItem>
+
+            <MotionItem>
+              <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+                <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/screener">
+                  <button className="px-8 py-4 gradient-primary text-white rounded-lg font-semibold hover:opacity-90 transition-all hover-lift text-lg" data-testid="button-start-screening" style={{ fontFamily: 'Times New Roman, serif' }}>
+                    Start Screening Stocks
+                    <ArrowRight className="inline ml-2" size={20} />
+                  </button>
+                </a>
+                <Link href="/about">
+                  <button className="px-8 py-4 glass-dark text-foreground rounded-lg font-semibold hover:opacity-90 transition-all hover-lift text-lg" data-testid="button-learn-more" style={{ fontFamily: 'Times New Roman, serif' }}>
+                    Learn More
+                  </button>
+                </Link>
               </div>
-              <div className="inline font-bold" style={{ color: 'rgba(25, 95, 255, 1)' }}>
-                Every Street
-              </div>
-            </h1>
-            <p className="text-xl text-muted-foreground mb-8 max-w-3xl mx-auto" style={{ font: 'italic 400 20px/28px "Times New Roman", serif' }}>
-              Our mission is to bridge the gap between knowledge and capital markets by offering cutting-edge screening tools and a first-of-its-kind Student Managed Investment Fund, fostering financial literacy and confident investing.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-              <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/screener">
-                <button className="px-8 py-4 gradient-primary text-white rounded-lg font-semibold hover:opacity-90 transition-all hover-lift text-lg" data-testid="button-start-screening" style={{ fontFamily: 'Times New Roman, serif' }}>
-                  Start Screening Stocks
-                  <ArrowRight className="inline ml-2" size={20} />
-                </button>
-              </a>
-              <Link href="/about">
-                <button className="px-8 py-4 glass-dark text-foreground rounded-lg font-semibold hover:opacity-90 transition-all hover-lift text-lg" data-testid="button-learn-more" style={{ fontFamily: 'Times New Roman, serif' }}>
-                  Learn More
-                </button>
-              </Link>
-            </div>
-          </motion.div>
+            </MotionItem>
+          </MotionContainer>
         </div>
       </section>
 
@@ -62,11 +66,7 @@ export default function Home() {
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {/* Stock Screener */}
-          <motion.div
-            className="bg-card rounded-xl p-8 border border-border hover-lift"
-            whileHover={{ y: -4 }}
-            data-testid="card-feature-screener"
-          >
+          <MotionItem className="bg-card rounded-xl p-8 border border-border hover-lift" whileHover={{ y: -4 }} data-testid="card-feature-screener">
             <div className="w-16 h-16 gradient-primary rounded-xl flex items-center justify-center mb-6">
               <Filter className="text-white" size={28} />
             </div>
@@ -79,14 +79,10 @@ export default function Home() {
                 Explore Screener <ArrowRight size={16} className="ml-2" />
               </a>
             </Link>
-          </motion.div>
+          </MotionItem>
 
           {/* MAYS SMIF */}
-          <motion.div
-            className="bg-card rounded-xl p-8 border border-border hover-lift"
-            whileHover={{ y: -4 }}
-            data-testid="card-feature-smif"
-          >
+          <MotionItem className="bg-card rounded-xl p-8 border border-border hover-lift" whileHover={{ y: -4 }} data-testid="card-feature-smif">
             <div className="w-16 h-16 gradient-primary rounded-xl flex items-center justify-center mb-6">
               <Users className="text-white" size={28} />
             </div>
@@ -99,14 +95,10 @@ export default function Home() {
                 Join Now <ArrowRight size={16} className="ml-2" />
               </a>
             </Link>
-          </motion.div>
+          </MotionItem>
 
           {/* Education */}
-          <motion.div
-            className="bg-card rounded-xl p-8 border border-border hover-lift"
-            whileHover={{ y: -4 }}
-            data-testid="card-feature-learn"
-          >
+          <MotionItem className="bg-card rounded-xl p-8 border border-border hover-lift" whileHover={{ y: -4 }} data-testid="card-feature-learn">
             <div className="w-16 h-16 gradient-primary rounded-xl flex items-center justify-center mb-6">
               <GraduationCap className="text-white" size={28} />
             </div>
@@ -119,7 +111,7 @@ export default function Home() {
                 Start Learning <ArrowRight size={16} className="ml-2" />
               </a>
             </Link>
-          </motion.div>
+          </MotionItem>
         </div>
       </section>
     </div>

--- a/client/src/pages/Learn.tsx
+++ b/client/src/pages/Learn.tsx
@@ -59,7 +59,7 @@ const indicators = [
 
 export default function Learn() {
   return (
-    <section className="bg-background min-h-screen py-20" data-testid="page-learn">
+    <MotionContainer className="bg-background min-h-screen py-20" data-testid="page-learn">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-4xl font-bold text-foreground mb-4">Learn Before You Invest</h2>
@@ -72,7 +72,7 @@ export default function Learn() {
           {indicators.map((indicator, index) => {
             const Icon = indicator.icon;
             return (
-              <div key={index} className="bg-card rounded-xl p-6 border border-border hover-lift" data-testid={`card-indicator-${index}`}>
+              <MotionItem key={index} className="bg-card rounded-xl p-6 border border-border hover-lift" data-testid={`card-indicator-${index}`}>
                 <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-4">
                   <Icon className="text-primary" size={24} />
                 </div>
@@ -82,7 +82,7 @@ export default function Learn() {
                   <div className="text-xs text-muted-foreground mb-1">Formula</div>
                   <div className="font-mono text-sm text-foreground">{indicator.formula}</div>
                 </div>
-              </div>
+              </MotionItem>
             );
           })}
         </div>
@@ -93,6 +93,6 @@ export default function Learn() {
           </button>
         </div>
       </div>
-    </section>
+    </MotionContainer>
   );
 }

--- a/client/src/pages/Learn.tsx
+++ b/client/src/pages/Learn.tsx
@@ -1,5 +1,7 @@
 import { BarChart3, Percent, Coins, Building, Activity, Scale, Calculator, Droplet, DollarSign } from "lucide-react";
 
+import { MotionContainer, MotionItem } from "@/components/Motion";
+
 const indicators = [
   {
     icon: BarChart3,

--- a/client/src/pages/SMIF.tsx
+++ b/client/src/pages/SMIF.tsx
@@ -1,6 +1,6 @@
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
 import { ArrowRight } from "lucide-react";
 import { formatCurrency } from "@/lib/stockData";
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, Legend } from "recharts";
 import { MotionContainer, MotionItem } from "@/components/Motion";
 
 const performanceData = [
@@ -21,119 +21,124 @@ const holdings = [
 
 export default function SMIF() {
   return (
-    <div className="bg-background min-h-screen py-20" data-testid="page-smif">
+    <MotionContainer className="bg-background min-h-screen py-20" data-testid="page-smif">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
-          <h2 className="text-4xl font-bold text-foreground mb-4">MAYS Student Managed Investment Fund</h2>
-          <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-            Pakistan's first Student Managed Investment Fund - Learn by managing a real portfolio
-          </p>
-        </div>
+        <MotionItem>
+          <div className="text-center mb-12">
+            <h2 className="text-4xl font-bold text-foreground mb-4">MAYS Student Managed Investment Fund</h2>
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
+              Pakistan's first Student Managed Investment Fund - Learn by managing a real portfolio
+            </p>
+          </div>
+        </MotionItem>
 
-        {/* Performance Chart */}
-        <div className="bg-card rounded-xl p-8 border border-border mb-12">
-          <div className="flex items-center justify-between mb-6">
-            <h3 className="text-2xl font-semibold text-foreground">Portfolio Performance</h3>
-            <div className="flex items-center space-x-4">
-              <div className="text-right">
-                <div className="text-sm text-muted-foreground">Total Returns</div>
-                <div className="text-2xl font-bold text-success">+24.8%</div>
-              </div>
-              <div className="text-right">
-                <div className="text-sm text-muted-foreground">Outperformance vs KSE-100</div>
-                <div className="text-2xl font-bold text-primary">+8.3%</div>
+        <MotionItem>
+          <div className="bg-card rounded-xl p-8 border border-border mb-12">
+            <div className="flex items-center justify-between mb-6">
+              <h3 className="text-2xl font-semibold text-foreground">Portfolio Performance</h3>
+              <div className="flex items-center space-x-4">
+                <div className="text-right">
+                  <div className="text-sm text-muted-foreground">Total Returns</div>
+                  <div className="text-2xl font-bold text-success">+24.8%</div>
+                </div>
+                <div className="text-right">
+                  <div className="text-sm text-muted-foreground">Outperformance vs KSE-100</div>
+                  <div className="text-2xl font-bold text-primary">+8.3%</div>
+                </div>
               </div>
             </div>
+
+            <ResponsiveContainer width="100%" height={320}>
+              <LineChart data={performanceData}>
+                <XAxis dataKey="month" stroke="hsl(var(--muted-foreground))" />
+                <YAxis stroke="hsl(var(--muted-foreground))" />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: 'hsl(var(--card))',
+                    border: '1px solid hsl(var(--border))',
+                    borderRadius: '8px',
+                  }}
+                />
+                <Legend />
+                <Line
+                  type="monotone"
+                  dataKey="smif"
+                  stroke="hsl(var(--success))"
+                  strokeWidth={3}
+                  name="MAYS SMIF Performance"
+                />
+                <Line
+                  type="monotone"
+                  dataKey="kse"
+                  stroke="hsl(var(--primary))"
+                  strokeWidth={3}
+                  name="KSE-100 Performance"
+                />
+              </LineChart>
+            </ResponsiveContainer>
           </div>
+        </MotionItem>
 
-          <ResponsiveContainer width="100%" height={320}>
-            <LineChart data={performanceData}>
-              <XAxis dataKey="month" stroke="hsl(var(--muted-foreground))" />
-              <YAxis stroke="hsl(var(--muted-foreground))" />
-              <Tooltip
-                contentStyle={{
-                  backgroundColor: 'hsl(var(--card))',
-                  border: '1px solid hsl(var(--border))',
-                  borderRadius: '8px',
-                }}
-              />
-              <Legend />
-              <Line
-                type="monotone"
-                dataKey="smif"
-                stroke="hsl(var(--success))"
-                strokeWidth={3}
-                name="MAYS SMIF Performance"
-              />
-              <Line
-                type="monotone"
-                dataKey="kse"
-                stroke="hsl(var(--primary))"
-                strokeWidth={3}
-                name="KSE-100 Performance"
-              />
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
-
-        {/* Holdings Table */}
-        <div className="bg-card rounded-xl p-8 border border-border mb-12">
-          <h3 className="text-2xl font-semibold text-foreground mb-6">Current Holdings</h3>
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead>
-                <tr className="border-b border-border">
-                  <th className="text-left py-3 px-4 text-sm font-semibold text-muted-foreground">Symbol</th>
-                  <th className="text-left py-3 px-4 text-sm font-semibold text-muted-foreground">Company</th>
-                  <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">Shares</th>
-                  <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">Price</th>
-                  <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">Value</th>
-                  <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">Weight</th>
-                  <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">Return</th>
-                </tr>
-              </thead>
-              <tbody>
-                {holdings.map((holding) => (
-                  <tr key={holding.symbol} className="border-b border-border hover:bg-muted transition-colors" data-testid={`row-holding-${holding.symbol}`}>
-                    <td className="py-3 px-4">
-                      <div className="text-sm font-semibold text-foreground">{holding.symbol}</div>
-                    </td>
-                    <td className="py-3 px-4">
-                      <div className="text-sm text-foreground">{holding.name}</div>
-                    </td>
-                    <td className="py-3 px-4 text-right">
-                      <div className="text-sm text-foreground">{holding.shares.toLocaleString()}</div>
-                    </td>
-                    <td className="py-3 px-4 text-right">
-                      <div className="text-sm text-foreground">{formatCurrency(holding.price)}</div>
-                    </td>
-                    <td className="py-3 px-4 text-right">
-                      <div className="text-sm font-semibold text-foreground">{formatCurrency(holding.value)}</div>
-                    </td>
-                    <td className="py-3 px-4 text-right">
-                      <div className="text-sm text-foreground">{holding.weight}%</div>
-                    </td>
-                    <td className="py-3 px-4 text-right">
-                      <div className="text-sm font-semibold text-success">+{holding.return}%</div>
-                    </td>
+        <MotionItem>
+          <div className="bg-card rounded-xl p-8 border border-border mb-12">
+            <h3 className="text-2xl font-semibold text-foreground mb-6">Current Holdings</h3>
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-border">
+                    <th className="text-left py-3 px-4 text-sm font-semibold text-muted-foreground">Symbol</th>
+                    <th className="text-left py-3 px-4 text-sm font-semibold text-muted-foreground">Company</th>
+                    <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">Shares</th>
+                    <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">Price</th>
+                    <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">Value</th>
+                    <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">Weight</th>
+                    <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">Return</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {holdings.map((holding) => (
+                    <tr key={holding.symbol} className="border-b border-border hover:bg-muted transition-colors" data-testid={`row-holding-${holding.symbol}`}>
+                      <td className="py-3 px-4">
+                        <div className="text-sm font-semibold text-foreground">{holding.symbol}</div>
+                      </td>
+                      <td className="py-3 px-4">
+                        <div className="text-sm text-foreground">{holding.name}</div>
+                      </td>
+                      <td className="py-3 px-4 text-right">
+                        <div className="text-sm text-foreground">{holding.shares.toLocaleString()}</div>
+                      </td>
+                      <td className="py-3 px-4 text-right">
+                        <div className="text-sm text-foreground">{formatCurrency(holding.price)}</div>
+                      </td>
+                      <td className="py-3 px-4 text-right">
+                        <div className="text-sm font-semibold text-foreground">{formatCurrency(holding.value)}</div>
+                      </td>
+                      <td className="py-3 px-4 text-right">
+                        <div className="text-sm text-foreground">{holding.weight}%</div>
+                      </td>
+                      <td className="py-3 px-4 text-right">
+                        <div className="text-sm font-semibold text-success">+{holding.return}%</div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
-        </div>
+        </MotionItem>
 
-        {/* Join CTA */}
-        <div className="glass-dark rounded-xl p-12 text-center">
-          <h3 className="text-3xl font-bold text-foreground mb-4">Ready to Join MAYS SMIF?</h3>
-          <p className="text-lg text-muted-foreground mb-8 max-w-2xl mx-auto">
-            Gain hands-on experience managing real investments. Learn portfolio construction, risk management, and market analysis from industry professionals.
-          </p>
-          <button className="px-8 py-4 gradient-primary text-white rounded-lg font-semibold hover:opacity-90 transition-all hover-lift text-lg" data-testid="button-apply-smif">
-            Apply Now <ArrowRight className="inline ml-2" size={20} />
-          </button>
-        </div>
+        <MotionItem>
+          <div className="glass-dark rounded-xl p-12 text-center">
+            <h3 className="text-3xl font-bold text-foreground mb-4">Ready to Join MAYS SMIF?</h3>
+            <p className="text-lg text-muted-foreground mb-8 max-w-2xl mx-auto">
+              Gain hands-on experience managing real investments. Learn portfolio construction, risk management, and market analysis from industry professionals.
+            </p>
+            <button className="px-8 py-4 gradient-primary text-white rounded-lg font-semibold hover:opacity-90 transition-all hover-lift text-lg" data-testid="button-apply-smif">
+              Apply Now <ArrowRight className="inline ml-2" size={20} />
+            </button>
+          </div>
+        </MotionItem>
       </div>
-    </div>
+    </MotionContainer>
   );
 }

--- a/client/src/pages/SMIF.tsx
+++ b/client/src/pages/SMIF.tsx
@@ -1,6 +1,7 @@
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
 import { ArrowRight } from "lucide-react";
 import { formatCurrency } from "@/lib/stockData";
+import { MotionContainer, MotionItem } from "@/components/Motion";
 
 const performanceData = [
   { month: 'Jan', smif: 100, kse: 100 },


### PR DESCRIPTION
## Purpose
The user requested adding nice, smooth animations to the home, MAYS SMIF, About Us, and Learn pages to make the site less boring and provide a better user experience when elements load in.

## Code changes
- **Created Motion components**: Added `Motion.tsx` with reusable `MotionContainer` and `MotionItem` components using Framer Motion for staggered animations
- **Updated About page**: Wrapped sections in motion components to enable smooth fade-in animations with staggered timing
- **Enhanced UI elements**: Added hover effects and improved visual styling with gradient backgrounds and icons
- **Refactored Navbar**: Simplified navigation structure and removed complex motion logic in favor of cleaner implementation

The animations use a staggered children approach with 0.08s delays and smooth easeOut transitions lasting 0.45s for a polished user experience.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b253b3edbe4d49088e637281fd3070a3/zen-sanctuary)

👀 [Preview Link](https://b253b3edbe4d49088e637281fd3070a3-zen-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b253b3edbe4d49088e637281fd3070a3</projectId>-->
<!--<branchName>zen-sanctuary</branchName>-->