### PR TITLE
Fix navigation by replacing anchor tags with Link components

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,45 +1,47 @@
+import { Link } from "wouter";
+
 export default function Navbar() {
   return (
     <header className="glass sticky top-0 z-50 shadow-sm" data-testid="navbar">
       <nav className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
-          <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/" data-testid="link-home">
+          <Link href="/" data-testid="link-home">
             <div className="flex items-center cursor-pointer">
               <span className="ml-2 text-foreground" style={{ font: '700 20px/28px "Times New Roman", serif' }}>FINBRIDGE</span>
             </div>
-          </a>
+          </Link>
 
           <div className="flex font-medium">
-            <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/" className="block">
+            <Link href="/" className="block">
               <div style={{ font: '500 14px/20px Times New Roman, serif', position: 'relative', transitionDuration: '0.15s', transitionProperty: 'color, background-color, border-color, text-decoration-color, fill, stroke', transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)' }}>
                 Home
               </div>
-            </a>
+            </Link>
 
-            <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/screener" className="block" style={{ marginLeft: '24px' }}>
+            <Link href="/screener" className="block" style={{ marginLeft: '24px' }}>
               <div style={{ font: '500 14px/20px Times New Roman, serif', position: 'relative', transitionDuration: '0.15s', transitionProperty: 'color, background-color, border-color, text-decoration-color, fill, stroke', transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)' }}>
                 Screener
               </div>
-            </a>
+            </Link>
 
-            <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/smif" className="block" style={{ marginLeft: '24px' }}>
+            <Link href="/smif" className="block" style={{ marginLeft: '24px' }}>
               <div style={{ font: '500 14px/20px Times New Roman, serif', position: 'relative', transitionDuration: '0.15s', transitionProperty: 'color, background-color, border-color, text-decoration-color, fill, stroke', transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)' }}>
                 MAYS SMIF
               </div>
-            </a>
+            </Link>
 
-            <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/about" className="block" style={{ marginLeft: '24px' }}>
+            <Link href="/about" className="block" style={{ marginLeft: '24px' }}>
               <div style={{ position: 'relative', display: 'inline', transitionDuration: '0.15s', transitionProperty: 'color, background-color, border-color, text-decoration-color, fill, stroke', transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)', font: '500 14px/20px Times New Roman, serif' }}>
                 <div style={{ fontFamily: 'Times New Roman, serif' }}>About Us</div>
                 <div style={{ bottom: '-4px', fontWeight: 500, height: '2px', left: 0, position: 'absolute', right: 0 }} />
               </div>
-            </a>
+            </Link>
 
-            <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/learn" className="block" style={{ marginLeft: '24px' }}>
+            <Link href="/learn" className="block" style={{ marginLeft: '24px' }}>
               <div style={{ font: '500 14px/20px Times New Roman, serif', position: 'relative', transitionDuration: '0.15s', transitionProperty: 'color, background-color, border-color, text-decoration-color, fill, stroke', transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)' }}>
                 Learn
               </div>
-            </a>
+            </Link>
           </div>
 
           <div style={{ backgroundImage: 'linear-gradient(135deg, rgb(54, 143, 231) 0%, rgb(25, 117, 210) 100%)', borderRadius: '12px', color: 'rgb(255, 255, 255)', display: 'block', fontSize: '14px', fontWeight: 500, lineHeight: '20px', textDecoration: 'rgb(255, 255, 255)', transitionDuration: '0.15s', transitionProperty: 'opacity', transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)', backgroundColor: 'rgba(0, 0, 0, 0)', borderColor: 'rgba(0, 0, 0, 0)', padding: '8px 16px' }}>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -37,16 +37,12 @@ export default function Home() {
 
             <MotionItem>
               <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-                <a href="https://b253b3edbe4d49088e637281fd3070a3-6fdc90ccde5b453c9bc61775a.fly.dev/screener">
-                  <button className="px-8 py-4 gradient-primary text-white rounded-lg font-semibold hover:opacity-90 transition-all hover-lift text-lg" data-testid="button-start-screening" style={{ fontFamily: 'Times New Roman, serif' }}>
-                    Start Screening Stocks
-                    <ArrowRight className="inline ml-2" size={20} />
-                  </button>
-                </a>
-                <Link href="/about">
-                  <button className="px-8 py-4 glass-dark text-foreground rounded-lg font-semibold hover:opacity-90 transition-all hover-lift text-lg" data-testid="button-learn-more" style={{ fontFamily: 'Times New Roman, serif' }}>
-                    Learn More
-                  </button>
+                <Link href="/screener" className="px-8 py-4 gradient-primary text-white rounded-lg font-semibold hover:opacity-90 transition-all hover-lift text-lg inline-flex items-center justify-center" data-testid="button-start-screening" style={{ fontFamily: 'Times New Roman, serif' }}>
+                  Start Screening Stocks
+                  <ArrowRight className="inline ml-2" size={20} />
+                </Link>
+                <Link href="/about" className="px-8 py-4 glass-dark text-foreground rounded-lg font-semibold hover:opacity-90 transition-all hover-lift text-lg inline-flex items-center justify-center" data-testid="button-learn-more" style={{ fontFamily: 'Times New Roman, serif' }}>
+                  Learn More
                 </Link>
               </div>
             </MotionItem>
@@ -74,10 +70,8 @@ export default function Home() {
             <p className="text-muted-foreground mb-4">
               Discover stocks with our advanced screening tool powered by 20+ performance and risk indicators. Designed for both beginners and experienced investors.
             </p>
-            <Link href="/screener">
-              <a className="text-primary font-semibold hover:underline inline-flex items-center" data-testid="link-explore-screener">
-                Explore Screener <ArrowRight size={16} className="ml-2" />
-              </a>
+            <Link href="/screener" className="text-primary font-semibold hover:underline inline-flex items-center" data-testid="link-explore-screener">
+              Explore Screener <ArrowRight size={16} className="ml-2" />
             </Link>
           </MotionItem>
 
@@ -90,10 +84,8 @@ export default function Home() {
             <p className="text-muted-foreground mb-4">
               Pakistan's first Student Managed Investment Fund. A unique opportunity for students to learn by managing a real portfolio.
             </p>
-            <Link href="/smif">
-              <a className="text-primary font-semibold hover:underline inline-flex items-center" data-testid="link-join-smif">
-                Join Now <ArrowRight size={16} className="ml-2" />
-              </a>
+            <Link href="/smif" className="text-primary font-semibold hover:underline inline-flex items-center" data-testid="link-join-smif">
+              Join Now <ArrowRight size={16} className="ml-2" />
             </Link>
           </MotionItem>
 
@@ -106,10 +98,8 @@ export default function Home() {
             <p className="text-muted-foreground mb-4">
               Financial literacy is the foundation of smart investing. Access guides, courses, and insights to understand market concepts and strategies.
             </p>
-            <Link href="/learn">
-              <a className="text-primary font-semibold hover:underline inline-flex items-center" data-testid="link-start-learning">
-                Start Learning <ArrowRight size={16} className="ml-2" />
-              </a>
+            <Link href="/learn" className="text-primary font-semibold hover:underline inline-flex items-center" data-testid="link-start-learning">
+              Start Learning <ArrowRight size={16} className="ml-2" />
             </Link>
           </MotionItem>
         </div>

--- a/client/src/pages/StockDetail.tsx
+++ b/client/src/pages/StockDetail.tsx
@@ -26,9 +26,7 @@ export default function StockDetail() {
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
           <h2 className="text-2xl font-bold text-foreground mb-4">Stock Not Found</h2>
-          <Link href="/screener">
-            <a className="text-primary hover:underline">Back to Screener</a>
-          </Link>
+          <Link href="/screener" className="text-primary hover:underline">Back to Screener</Link>
         </div>
       </div>
     );
@@ -47,10 +45,8 @@ export default function StockDetail() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="mb-8">
-          <Link href="/screener">
-            <button className="text-primary hover:text-primary/80 mb-4 inline-flex items-center" data-testid="button-back-to-screener">
-              <ArrowLeft size={20} className="mr-2" /> Back to Screener
-            </button>
+          <Link href="/screener" className="text-primary hover:text-primary/80 mb-4 inline-flex items-center" data-testid="button-back-to-screener">
+            <ArrowLeft size={20} className="mr-2" /> Back to Screener
           </Link>
           <div className="flex items-start justify-between">
             <div>


### PR DESCRIPTION
## Purpose
The user reported that pages besides the home page weren't loading or working properly. This indicates a navigation issue where clicking on navigation links was not properly routing to different pages in the single-page application.

## Code changes
- **Navbar.tsx**: Replaced all hardcoded anchor tags (`<a>`) with `Link` components from wouter router
  - Added import for `Link` from "wouter"
  - Converted absolute URLs to relative paths (e.g., `/screener`, `/smif`, `/about`, `/learn`)
  - Maintained all existing styling and data-testid attributes

- **Home.tsx**: Updated call-to-action buttons and feature links
  - Replaced nested `<a>` tags inside `Link` components with direct `Link` usage
  - Applied button styling directly to `Link` components
  - Added proper flex classes for consistent button appearance

- **StockDetail.tsx**: Simplified navigation links
  - Removed unnecessary nested `<a>` tags within `Link` components
  - Applied styling directly to `Link` components

These changes ensure proper client-side routing functionality, allowing users to navigate between pages without full page reloads.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b253b3edbe4d49088e637281fd3070a3/nova-haven)

👀 [Preview Link](https://b253b3edbe4d49088e637281fd3070a3-nova-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b253b3edbe4d49088e637281fd3070a3</projectId>-->
<!--<branchName>nova-haven</branchName>-->